### PR TITLE
org.yocto.crops.target: drop invalid site, cleanup pom.xmls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,8 @@
 	</prerequisites>
 
     <properties>
-	<eclipse-crops-version>0.3.0</eclipse-crops-version>
-	<tycho-version>0.25.0</tycho-version>
-	<tycho-extras-version>0.25.0</tycho-extras-version>
+	<tycho-version>0.26.0</tycho-version>
+	<tycho-extras-version>0.26.0</tycho-extras-version>
 	<target-platform>crops</target-platform>
 	<help-docs-eclipserun-repo>http://download.eclipse.org/eclipse/updates/4.6</help-docs-eclipserun-repo>
 	<tycho.scmUrl>scm:git:https://github.com/crops/eclipse-crops.git</tycho.scmUrl>
@@ -248,7 +247,7 @@
 							<groupId>org.yocto.crops</groupId>
 							<artifactId>org.yocto.crops.target</artifactId>
 							<classifier>${target-platform}</classifier>
-							<version>${eclipse-crops-version}</version>
+							<version>0.3.0-SNAPSHOT</version>
 						</artifact>
 					</target>
 				</configuration>

--- a/releng/org.yocto.crops.target/crops.target
+++ b/releng/org.yocto.crops.target/crops.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-crops" sequenceNumber="7">
+<?pde version="3.8"?><target name="eclipse-crops" sequenceNumber="8">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="http://download.eclipse.org/tm/updates/4.0/"/>
@@ -78,11 +78,6 @@
 <unit id="org.antlr.runtime" version="4.5.1.v20160210-1233"/>
 <unit id="org.freemarker.source" version="2.3.22.v20160210-1233"/>
 <repository location="https://hudson.eclipse.org/orbit/job/orbit-recipes/lastSuccessfulBuild/artifact/releng/repository/target/repository/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.launchbar.remote.feature.group" version="1.0.1.201611031744"/>
-<unit id="org.eclipse.launchbar.remote.source.feature.group" version="1.0.1.201611031744"/>
-<repository location="https://hudson.eclipse.org/cdt/job/launchbar-master/lastSuccessfulBuild/artifact/repo/target/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tm.terminal.view.rse.feature.feature.group" version="4.1.0.201606052351"/>

--- a/releng/org.yocto.crops.target/pom.xml
+++ b/releng/org.yocto.crops.target/pom.xml
@@ -10,9 +10,8 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<groupId>org.yocto.crops</groupId>
+	<groupId>org.yocto.crops.target</groupId>
 	<artifactId>org.yocto.crops.target</artifactId>
-	<version>${eclipse-crops-version}</version>
 	<packaging>pom</packaging>
 	
 	<build>


### PR DESCRIPTION
- Update tycho from 0.25 -> 0.26
- Drop ${eclipse-crops-version} variable to silence warning
- Launchbar is in mainline Eclipse now

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>