### PR TITLE
Added crops-dev target based upon linuxtools 5.2, Eclipse neon.2, CDT

### DIFF
--- a/releng/org.yocto.crops.target/crops-dev.target
+++ b/releng/org.yocto.crops.target/crops-dev.target
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target includeMode="feature" name="crops-dev" sequenceNumber="24">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
+<unit id="org.glassfish.jersey.core.jersey-client" version="2.14.0.v201504211925"/>
+<unit id="com.spotify.docker.client.source" version="3.4.0.v20160411-1914"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.14.0.v201504171603"/>
+<unit id="com.google.guava" version="15.0.0.v201403281430"/>
+<unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
+<unit id="org.glassfish.hk2.locator" version="2.3.0.b10_v201508191500"/>
+<unit id="org.aopalliance" version="1.0.0.v201105210816"/>
+<unit id="org.apache.commons.compress" version="1.6.0.v201310281400"/>
+<unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.docker.feature.source.feature.group" version="2.2.0.201612072123"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.5.0.v201504171603"/>
+<unit id="org.bouncycastle.bcpkix" version="1.52.0.v20160915-1535"/>
+<unit id="org.glassfish.jersey.bundles.repackaged.jersey-guava" version="2.14.0.v201504151636"/>
+<unit id="org.glassfish.jersey.core.jersey-common" version="2.14.0.v201504171603"/>
+<unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.5.0.v201504171603"/>
+<unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.5.0.v201504151636"/>
+<unit id="jnr.posix" version="3.0.9.v201505052040"/>
+<unit id="jnr.unixsocket" version="0.5.0.v201505052040"/>
+<unit id="javassist" version="3.13.0.GA_v201209210905"/>
+<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.2.0.201612072123"/>
+<unit id="org.glassfish.hk2.api" version="2.3.0.b10_v201508191500"/>
+<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="2.5.0.v201504151636"/>
+<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+<unit id="com.kenai.jffi" version="1.2.7.v201505052040"/>
+<unit id="org.eclipse.linuxtools.vagrant.feature.source.feature.group" version="2.2.0.201612072123"/>
+<unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
+<unit id="org.glassfish.jersey.apache.connector" version="2.14.0.v201504171603"/>
+<unit id="org.objectweb.asm" version="5.1.0.v20160914-0701"/>
+<unit id="org.glassfish.hk2.osgi-resource-locator" version="2.3.0.b10_v201508191500"/>
+<unit id="jnr.enxio" version="0.6.0.v201505052040"/>
+<unit id="jnr.constants" version="0.8.6.v201505052040"/>
+<unit id="org.glassfish.hk2.utils" version="2.3.0.b10_v201508191500"/>
+<unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
+<unit id="org.bouncycastle.bcprov" version="1.52.0.v20160915-1535"/>
+<unit id="jnr.ffi" version="2.0.1.v201505052040"/>
+<unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
+<repository location="http://download.eclipse.org/linuxtools/update-docker-2.2.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/cbi/updates/license"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.tm.terminal.view.rse.feature.feature.group" version="4.2.0.201611281915"/>
+<unit id="org.eclipse.mylyn.hudson.feature.group" version="1.13.0.v20160806-1446"/>
+<unit id="org.eclipse.egit.mylyn.feature.group" version="4.4.1.201607150455-r"/>
+<unit id="org.eclipse.cdt.sdk.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.cdt.launch.remote.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.oomph.version.feature.group" version="1.6.0.v20161019-0656"/>
+<unit id="org.eclipse.remote.feature.group" version="2.1.1.201612062149"/>
+<unit id="org.eclipse.oomph.preferences.feature.group" version="1.6.0.v20161019-0656"/>
+<unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160603-1933"/>
+<unit id="org.eclipse.cdt.debug.gdbjtag.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.cdt.build.crossgcc.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.oomph.setup.sdk.feature.group" version="1.6.0.v20161128-0928"/>
+<unit id="org.eclipse.cdt.docker.launcher.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
+<unit id="org.eclipse.tcf.rse.feature.feature.group" version="1.4.0.201604292020"/>
+<unit id="org.eclipse.rcptt.platform.feature.group" version="2.1.0.201605312329"/>
+<unit id="org.eclipse.mylyn.team_feature.feature.group" version="3.21.0.v20160701-1337"/>
+<unit id="org.eclipse.launchbar.feature.group" version="2.1.0.201612052026"/>
+<unit id="org.eclipse.rse.feature.group" version="3.7.2.201610260947"/>
+<unit id="org.eclipse.tm.terminal.feature.feature.group" version="4.2.0.201611281915"/>
+<unit id="org.eclipse.egit.feature.group" version="4.4.1.201607150455-r"/>
+<unit id="org.eclipse.mylyn.pde_feature.feature.group" version="3.21.0.v20160701-1337"/>
+<unit id="org.eclipse.xtend.sdk.feature.group" version="2.10.0.v201605250459"/>
+<unit id="org.eclipse.tcf.cdt.feature.feature.group" version="1.4.0.201606031137"/>
+<unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.21.0.v20160909-1813"/>
+<unit id="org.eclipse.oomph.projectconfig.feature.group" version="1.6.0.v20161019-0656"/>
+<unit id="org.eclipse.oomph.targlets.feature.group" version="1.6.0.v20161104-0635"/>
+<unit id="org.eclipse.mylyn_feature.feature.group" version="3.21.0.v20160914-0252"/>
+<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.8.0.v201608061842"/>
+<unit id="org.eclipse.oomph.workingsets.feature.group" version="1.6.0.v20161111-1110"/>
+<unit id="org.eclipse.tcf.te.tcf.feature.feature.group" version="1.4.0.201603240930"/>
+<unit id="org.eclipse.cdt.autotools.feature.group" version="9.2.0.201612061315"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.remote.console.feature.group" version="2.1.1.201612062149"/>
+<unit id="org.eclipse.wst.xsl.feature.feature.group" version="1.3.401.v201509231858"/>
+<repository location="http://download.eclipse.org/releases/neon/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.6.2.M20161124-1400"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.linuxtools.valgrind.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.oprofile.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.apache.xerces" version="2.9.0.v201101211617"/>
+<unit id="org.eclipse.linuxtools.profiling.remote.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.changelog.c.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.perf.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.valgrind.remote.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.rpm.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.man.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.dataviewers.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.perf.remote.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.newlib.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.apache.xml.serializer" version="2.7.1.v201005080400"/>
+<unit id="org.eclipse.linuxtools.changelog.java.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.changelog.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.valgrind.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.perf.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.rpm.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.oprofile.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.systemtap.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.gprof.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.gcov.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.profiling.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.man.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.callgraph.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="javax.xml" version="1.3.4.v201005080400"/>
+<unit id="org.eclipse.linuxtools.dataviewers.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.apache.xml.resolver" version="1.2.0.v201005080400"/>
+<unit id="org.eclipse.linuxtools.valgrind.remote.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.gcov.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.changelog.java.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.swtchart" version="0.10.0.v201605200358"/>
+<unit id="org.eclipse.linuxtools.changelog.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.profiling.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.gprof.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.oprofile.remote.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.systemtap.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.javadocs.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.callgraph.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.perf.remote.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.profiling.remote.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.cyberneko.html" version="1.9.14.v201105210654"/>
+<unit id="org.eclipse.linuxtools.changelog.c.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.oprofile.remote.feature.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.javadocs.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.source.feature.group" version="5.2.0.201612072123"/>
+<unit id="org.eclipse.linuxtools.cdt.libhover.newlib.feature.source.feature.group" version="5.2.0.201612072123"/>
+<repository location="http://download.eclipse.org/linuxtools/update-5.2.0"/>
+</location>
+</locations>
+</target>


### PR DESCRIPTION
Hi Tim and Brian,

Here's a crops-dev.target file added to releng with target consisting of linuxtools 5.2, linuxtools docker support, CDT 9.2 and eclipse neon.2 deps.  Also includes sources of appropriate versions...for docker support.   I'm able to resolve and run this target successfully in neon.2.   If either of you are not for whatever reason let me know and I will fix and resubmit pull request off of my fork.